### PR TITLE
add a solution for self signed SSL certificate

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,14 @@ pip install black
 black --verbose 001-quickstart/app.py
 ```
 
+### Troubleshooting
+
+If you use a self-signed certificate to connect your Cosmos DB instance (Cosmos-emulator, Docker image, proxy, ...), you can define your own certificate in the `REQUESTS_CA_BUNDLE` environment variable :
+
+```bash
+export REQUESTS_CA_BUNDLE='/etc/ssl/certs/emulatorcert.pem'
+```
+
 ## Samples
 
 This project contains multiple samples used in [Azure Cosmos DB for NoSQL](https://learn.microsoft.com/azure/cosmos-db/nosql/) documentation.


### PR DESCRIPTION
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Provide your own certificate to avoid verification error without altering the application code :

azure.core.exceptions.ServiceRequestError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:997)

<!-- Verify that you have linted and formatted your Python code correctly -->

No code change.